### PR TITLE
raise error on failed bandit run

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,8 @@ def _run_bandit(from_directory: str) -> Optional[Dict[str, Any]]:
     out = results.stdout
     if out is None:
         raise Exception(results.stderr)
+    if out["errors"] != []:
+        raise Exception(out["errors"])
     return out
 
 


### PR DESCRIPTION
If `bandit` errors, so should the workflow