### PR TITLE
do not raise exception on failed bandit

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,9 +54,7 @@ def _run_bandit(from_directory: str) -> Optional[Dict[str, Any]]:
     results = run_command(f"bandit -r -f json {from_directory}", is_json=True, raise_on_error=False)
     out = results.stdout
     if out is None:
-        raise Exception(results.stderr)
-    if out["errors"] != []:
-        raise Exception(out["errors"])
+        out = {"errors": [results.stderr]}
     return out
 
 

--- a/app.py
+++ b/app.py
@@ -52,9 +52,14 @@ init_logging()
 
 def _run_bandit(from_directory: str) -> Optional[Dict[str, Any]]:
     results = run_command(f"bandit -r -f json {from_directory}", is_json=True, raise_on_error=False)
-    out = results.stdout
+    out = results.stdout  # type: dict
     if out is None:
-        out = {"errors": [results.stderr]}
+        out = {"error_messages": [results.stderr], "error": True}
+    elif out["errors"] != []:
+        out["error_messages"] = out.pop("errors")
+        out["error"] = True
+
+    out["error"] = False
     return out
 
 


### PR DESCRIPTION
## Related Issues and Dependencies

#39 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Instead of raising error, we should check for errors during `si-aggregate` and `graph-sync` so that we don't repeatedly schedule for packages which we cannot solve.

